### PR TITLE
support for additional tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,33 @@ Generic Setup profile must be installed, which registers a JavaScript
 including the raven library and the configuration.
 
 
+Additional tags
+===============
+
+It is possible to report additional, predefined tags for a deployment.
+The tags may be directly declared as JSON in the environment variable
+``RAVEN_TAGS`` or the variable ``RAVEN_TAGS_FILE`` may contain a path
+to a json-file.
+These two methods may be combined, and the respective dictionaries will
+be merged (with tags from the ``RAVEN_TAGS`` variable taking precedence).
+
+The JSON must be a one-level hash containing strings as keys and values.
+
+Examples:
+
+.. code::
+
+    [instance]
+    environment-vars +=
+        RAVEN_TAGS {"deployment": "production"}
+
+.. code::
+
+    [instance]
+    environment-vars +=
+        RAVEN_TAGS_FILE ${buildout:directory}/conf/raven_tags.json
+
+
 Links
 =====
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- New environment variables ``RAVEN_TAGS`` and ``RAVEN_TAGS_FILE`` for
+  making it possible to attach additional static tags. [jone]
 
 
 1.0.2 (2016-01-15)

--- a/ftw/raven/browser/javascript.py
+++ b/ftw/raven/browser/javascript.py
@@ -49,6 +49,10 @@ class RavenJavaScript(BrowserView):
         if hasattr(socket, 'gethostname'):
             args['serverName'] = socket.gethostname()
 
+        tags = reporter.prepare_tags()
+        if tags:
+            args['tags'] = tags
+
         return args
 
     def _get_dsn_without_private_key(self):

--- a/ftw/raven/reporter.py
+++ b/ftw/raven/reporter.py
@@ -4,6 +4,7 @@ from ftw.raven.client import get_raven_client
 from ftw.raven.config import get_raven_config
 from pkg_resources import DistributionNotFound
 from pkg_resources import get_distribution
+from plone.memoize import forever
 from raven import fetch_git_sha
 from raven.exceptions import InvalidGitRepository
 from yolk.yolklib import Distributions
@@ -28,7 +29,8 @@ def maybe_report_exception(context, request, exc_type, exc, traceback):
             data = {'request': prepare_request_infos(request),
                     'user': prepare_user_infos(context, request),
                     'extra': prepare_extra_infos(context, request),
-                    'modules': prepare_modules_infos()}
+                    'modules': prepare_modules_infos(),
+                    'tags': prepare_tags()}
             release = get_release()
             if release:
                 data['release'] = release
@@ -126,6 +128,11 @@ def prepare_modules_infos():
     modules = dict((dist.project_name, dist.version) for dist in dists)
     modules['python'] = '.'.join(map(str, sys.version_info[:3]))
     return modules
+
+
+@forever.memoize
+def prepare_tags():
+    return get_raven_config().tags
 
 
 def get_release():

--- a/ftw/raven/testing.py
+++ b/ftw/raven/testing.py
@@ -4,6 +4,7 @@ from ftw.builder.testing import set_builder_session_factory
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PloneSandboxLayer
+from plone.memoize import forever
 from plone.testing import z2
 from zope.configuration import xmlconfig
 import os
@@ -29,6 +30,9 @@ class RavenLayer(PloneSandboxLayer):
         for name in os.environ.keys():
             if name.startswith('RAVEN'):
                 del os.environ[name]
+
+        # purge forever caches
+        forever._memos.clear()
 
 
 RAVEN_FIXTURE = RavenLayer()

--- a/ftw/raven/tests/test_integration.py
+++ b/ftw/raven/tests/test_integration.py
@@ -104,6 +104,11 @@ class TestIntegration(FunctionalTestCase):
         self.request_to_error_view(view='make_404_err')
         self.assertEquals(1, len(get_raven_client().captureException_calls))
 
+    def test_additional_tags_are_reported(self):
+        os.environ['RAVEN_TAGS'] = '{"maintainer": "hugo"}'
+        call = self.make_error_and_get_capture_call()
+        self.assertEquals({'maintainer': 'hugo'}, call['data']['tags'])
+
     def make_error_and_get_capture_call(self, **kwargs):
         os.environ['RAVEN_DSN'] = 'https://x:y@sentry.local/1'
         self.request_to_error_view(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(name='ftw.raven',
 
       install_requires=[
           'Plone',
+          'plone.memoize',
           'raven',
           'setuptools',
           'yolk',


### PR DESCRIPTION
It is now possible to define additional tags which will be sent along with each error.

The tags can either be defined directly as JSON in the ``RAVEN_TAGS`` environment variable or by declaring a path to a JSON-file in the variable ``RAVEN_TAGS_FILE``.

Closes #3 