### PR TITLE
Report error_log number as tag

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
+- Report error_log number as tag. [jone]
+
 - Add a view ``raven-test`` and a JavaScript function ``raven_test()``
   for testing the raven configuration and connection. Both will throw
   an exception which will be reported to sentry. [jone]

--- a/ftw/raven/browser/javascript.py
+++ b/ftw/raven/browser/javascript.py
@@ -68,7 +68,7 @@ class RavenJavaScript(BrowserView):
         if hasattr(socket, 'gethostname'):
             args['serverName'] = socket.gethostname()
 
-        tags = reporter.prepare_tags()
+        tags = reporter.get_default_tags()
         if tags:
             args['tags'] = tags
 

--- a/ftw/raven/reporter.py
+++ b/ftw/raven/reporter.py
@@ -30,7 +30,7 @@ def maybe_report_exception(context, request, exc_type, exc, traceback):
                     'user': prepare_user_infos(context, request),
                     'extra': prepare_extra_infos(context, request),
                     'modules': prepare_modules_infos(),
-                    'tags': prepare_tags()}
+                    'tags': prepare_tags(exc)}
             release = get_release()
             if release:
                 data['release'] = release
@@ -130,9 +130,16 @@ def prepare_modules_infos():
     return modules
 
 
+def prepare_tags(exc):
+    tags = get_default_tags()
+    if hasattr(exc, 'error_log_id'):
+        tags['error_log_id'] = exc.error_log_id
+    return tags
+
+
 @forever.memoize
-def prepare_tags():
-    return get_raven_config().tags
+def get_default_tags():
+    return get_raven_config().tags.copy()
 
 
 def get_release():

--- a/ftw/raven/tests/test_integration.py
+++ b/ftw/raven/tests/test_integration.py
@@ -104,10 +104,15 @@ class TestIntegration(FunctionalTestCase):
         self.request_to_error_view(view='make_404_err')
         self.assertEquals(1, len(get_raven_client().captureException_calls))
 
+    def test_error_log_id_is_reported_as_tag(self):
+        call = self.make_error_and_get_capture_call()
+        self.assertIn('error_log_id', call['data']['tags'])
+
     def test_additional_tags_are_reported(self):
         os.environ['RAVEN_TAGS'] = '{"maintainer": "hugo"}'
         call = self.make_error_and_get_capture_call()
-        self.assertEquals({'maintainer': 'hugo'}, call['data']['tags'])
+        self.assertDictContainsSubset({'maintainer': 'hugo'},
+                                      call['data']['tags'])
 
     def make_error_and_get_capture_call(self, **kwargs):
         os.environ['RAVEN_DSN'] = 'https://x:y@sentry.local/1'


### PR DESCRIPTION
When an error occurs, an error-number is shown to the user on the error page.
We now attach this number as tag ``error_log_id``, allowing to search in sentry for a specific error.

Closes #4