### PR TITLE
Javascript throws error when no raven config is defined.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Test if raven config is accessible in javascript integration.
+  [Kevin Bieri]
 
 
 1.1.1 (2016-01-20)

--- a/ftw/raven/browser/resources/raven-integration.js
+++ b/ftw/raven/browser/resources/raven-integration.js
@@ -1,4 +1,4 @@
-if (typeof(raven_config) != undefined) {
+if (typeof raven_config !== "undefined") {
   // From: https://gist.github.com/impressiver/5092952
   var ravenOptions = {
     // Will cause a deprecation warning, but the demise of `ignoreErrors` is still under discussion.


### PR DESCRIPTION
Test if raven config is accessible.