### PR TITLE
Also ignore `Intercepted` exceptions from plone.caching by default.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,8 +80,8 @@ Ignored exceptions
 
 By default, not all exceptions are reported, because some exceptions
 such as redirects or 404s are not errors but are implemented as exceptions.
-Without configuration, the exceptions ``NotFound``, ``Unauthorized`` and
-``Redirect``.
+Without configuration, the exceptions ``NotFound``, ``Unauthorized``,
+``Redirect`` and ``Intercepted``.
 
 Reporting of those exceptions can be enabled by with the environment variable
 ``RAVEN_ENABLE_EXCEPTIONS``:

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Also ignore `Intercepted` exceptions from plone.caching by default.
+  [lgraf]
 
 
 1.1.2 (2016-03-15)

--- a/ftw/raven/config.py
+++ b/ftw/raven/config.py
@@ -26,7 +26,7 @@ class RavenConfig(object):
 
     @property
     def ignored_exception_classnames(self):
-        ignored = set(['Redirect', 'NotFound', 'Unauthorized'])
+        ignored = set(['Redirect', 'NotFound', 'Unauthorized', 'Intercepted'])
         enabled = self._get_stripped_env_variable('RAVEN_ENABLE_EXCEPTIONS')
         if enabled:
             ignored -= set(map(str.strip, enabled.split(',')))

--- a/ftw/raven/tests/test_config.py
+++ b/ftw/raven/tests/test_config.py
@@ -28,20 +28,29 @@ class TestRavenConfig(FunctionalTestCase):
         self.assertEquals(parent_dir, get_raven_config().buildout_root)
 
     def test_ignored_exception_classnames(self):
-        self.assertEquals(set(['Redirect', 'NotFound', 'Unauthorized']),
-                          set(get_raven_config().ignored_exception_classnames))
+        self.assertEquals(
+            set(['Redirect', 'NotFound', 'Unauthorized', 'Intercepted']),
+            set(get_raven_config().ignored_exception_classnames))
 
         os.environ['RAVEN_ENABLE_EXCEPTIONS'] = 'NotFound'
-        self.assertEquals(set(['Redirect', 'Unauthorized']),
-                          set(get_raven_config().ignored_exception_classnames))
+        self.assertEquals(
+            set(['Redirect', 'Unauthorized', 'Intercepted']),
+            set(get_raven_config().ignored_exception_classnames))
 
         os.environ['RAVEN_ENABLE_EXCEPTIONS'] = 'Unauthorized, Redirect'
-        self.assertEquals(set(['NotFound']),
-                          set(get_raven_config().ignored_exception_classnames))
+        self.assertEquals(
+            set(['NotFound', 'Intercepted']),
+            set(get_raven_config().ignored_exception_classnames))
 
         os.environ['RAVEN_ENABLE_EXCEPTIONS'] = 'Unauthorized, Redirect, NotFound'
-        self.assertEquals(set(),
-                          set(get_raven_config().ignored_exception_classnames))
+        self.assertEquals(
+            set(['Intercepted']),
+            set(get_raven_config().ignored_exception_classnames))
+
+        os.environ['RAVEN_ENABLE_EXCEPTIONS'] = 'Unauthorized, Redirect, NotFound, Intercepted'
+        self.assertEquals(
+            set(),
+            set(get_raven_config().ignored_exception_classnames))
 
     def test_no_tags_by_default(self):
         self.assertEquals({}, get_raven_config().tags)


### PR DESCRIPTION
This adds `Intercepted` to the exception class names that are ignored by default.

This is intended to ignore [`plone.caching.hooks.Intercepted`](https://github.com/plone/plone.caching/blob/3bc4442ccf4bcace61d086d576f5e9df2b0f0fb8/plone/caching/hooks.py#L32-L43), which is an internal exception used for flow control that can regularly occur in normal operation. Fixes #15

@jone