### PR TITLE
Support for disabling reporting of custom exceptions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,15 @@ Reporting of those exceptions can be enabled by with the environment variable
     environment-vars +=
         RAVEN_ENABLE_EXCEPTIONS NotFound, Redirect
 
+If you need to disable custom exceptions, you can do that with the environment
+variable ``RAVEN_DISABLE_EXCEPTIONS``:
+
+.. code::
+
+    [instance]
+    environment-vars +=
+        RAVEN_DISABLE_EXCEPTIONS UnimportantError
+
 
 Report JavaScript errors
 ========================

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ``RAVEN_DISABLE_EXCEPTIONS`` environment variable
+  for allowing to disable reporting of custom exceptions. [jone]
 
 
 1.1.3 (2016-04-29)

--- a/ftw/raven/config.py
+++ b/ftw/raven/config.py
@@ -31,6 +31,10 @@ class RavenConfig(object):
         if enabled:
             ignored -= set(map(str.strip, enabled.split(',')))
 
+        disabled = self._get_stripped_env_variable('RAVEN_DISABLE_EXCEPTIONS')
+        if disabled:
+            ignored |= set(map(str.strip, disabled.split(',')))
+
         return tuple(ignored)
 
     @property

--- a/ftw/raven/tests/test_config.py
+++ b/ftw/raven/tests/test_config.py
@@ -52,6 +52,18 @@ class TestRavenConfig(FunctionalTestCase):
             set(),
             set(get_raven_config().ignored_exception_classnames))
 
+    def test_disabling_custom_exceptions(self):
+        self.assertNotIn('RandomError',
+                         get_raven_config().ignored_exception_classnames)
+
+        os.environ['RAVEN_DISABLE_EXCEPTIONS'] = 'RandomError'
+        self.assertIn('RandomError',
+                      get_raven_config().ignored_exception_classnames)
+
+        os.environ['RAVEN_DISABLE_EXCEPTIONS'] = 'Foo, RandomError, Bar'
+        self.assertIn('RandomError',
+                      get_raven_config().ignored_exception_classnames)
+
     def test_no_tags_by_default(self):
         self.assertEquals({}, get_raven_config().tags)
 


### PR DESCRIPTION
The new ``RAVEN_DISABLE_EXCEPTIONS`` environment variable makes it possible to configure a list of exception types which should not be reported.