### PR TITLE
Test against Plone 5.1.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
 zcml-additional-fragments +=

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Plone 5. [mbaechtold, jone]
 
 
 1.2.0 (2017-03-15)

--- a/ftw/raven/tests/test_integration.py
+++ b/ftw/raven/tests/test_integration.py
@@ -20,6 +20,13 @@ class TestIntegration(FunctionalTestCase):
     def test_request_infos(self):
         call = self.make_error_and_get_capture_call(data={'foo': '3'})
         self.maxDiff = None
+
+        expected = call['data']['request']
+
+        # "X-Theme-Enabled" is available on Plone 5 but not on Plone 4.
+        # It's irrelevant for our test so we can remove it.
+        expected['headers'].pop('X-Theme-Enabled', None)
+
         self.assertEquals(
             {'cookies': {},
              'url': 'http://nohost/plone/make_key_error',
@@ -37,7 +44,7 @@ class TestIntegration(FunctionalTestCase):
              'query_string': '',
              'data': {'foo': '3'},
              'method': 'POST'},
-            call['data']['request'])
+            expected)
 
     def test_user_infos_as_anonymous(self):
         call = self.make_error_and_get_capture_call()

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+
+package-name = ftw.raven


### PR DESCRIPTION
⚠️ `plone.app.linkintegrity` no longer patches `zpublisher_exception_hook` in Plone 5 so we need to patch the `ZPublisherExceptionHook` directly. By doing so we won't be able to capture exceptions in `plone.app.linkintegrity` in Plone 4 anymore, but we can live with that. ⚠️ 

Fixes #17 