### PR TITLE
Support for threaded+requests+https scheme in JS

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support ``threaded+requests+https`` dsn scheme in JS [Nachtalb]
 
 
 1.3.0 (2019-03-08)

--- a/ftw/raven/browser/javascript.py
+++ b/ftw/raven/browser/javascript.py
@@ -41,7 +41,7 @@ class RavenUserConfiguration(BrowserView):
 
     def _get_dsn_without_private_key(self):
         dsn = get_raven_config().dsn
-        return re.sub(r'(://[^:]*):[^@]*(@)', '\g<1>\g<2>', dsn)
+        return re.sub(r'(threaded\+requests\+)?([^:]*://[^:]*):[^@]*(@)', '\g<2>\g<3>', dsn)
 
 
 class RavenJavaScript(BrowserView):


### PR DESCRIPTION
By simply removing it, as it is only necessary for python and not JS.